### PR TITLE
New build target to package REPL as a save file

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -1,1 +1,28 @@
 SUBDIRS = cmd db dsp rpgle bnd 
+
+package:
+	$(call echo_cmd,"=== PACKAGE: Creating save file [$(OBJLIB)/RPGLEREPL]")
+	$(eval crtcmd := CRTSAVF FILE($(OBJLIB)/RPGLEREPL))
+	@$(PRESETUP);  \
+	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
+	$(POSTCLEANUP)
+	$(call echo_cmd,"=== PACKAGE: Granting public authority to library")
+	$(eval crtcmd := GRTOBJAUT OBJ($(OBJLIB)/*ALL) USER(*PUBLIC) OBJTYPE(*ALL) AUT(*ALL))
+	@$(PRESETUP);  \
+	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
+	$(POSTCLEANUP)
+	$(call echo_cmd,"=== PACKAGE: Granting public authority to objects")
+	$(eval crtcmd := GRTOBJAUT OBJ($(OBJLIB)/*ALL) USER(*PUBLIC) OBJTYPE(*ALL) AUT(*ALL))
+	@$(PRESETUP);  \
+	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
+	$(POSTCLEANUP)
+	$(call echo_cmd,"=== PACKAGE: Change ownership to QPGMR")
+	$(eval crtcmd := CHGOWN OBJ('/QSYS.LIB/$(OBJLIB).LIB') NEWOWN(QPGMR) SUBTREE(*ALL))
+	@$(PRESETUP);  \
+	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
+	$(POSTCLEANUP)
+	$(call echo_cmd,"=== PACKAGE: Saving objects to [$(OBJLIB)/RPGLEREPL]")
+	$(eval crtcmd := SAVOBJ OBJ(*ALL) LIB($(OBJLIB)) DEV(*SAVF) SAVF($(OBJLIB)/RPGLEREPL) CLEAR(*REPLACE) TGTRLS($(TGTRLS)) DTACPR(*YES) SELECT((*OMIT *ALL *FILE SAVF)))
+	@$(PRESETUP);  \
+	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
+	$(POSTCLEANUP)


### PR DESCRIPTION
A save file package can now be built through Bob. Simply run:

`makei all package`

This will create save file RPGLEREPL in the configured object library for the Bob build.

A build for a previous IBM i release can be done like this:

`makei all package TGTRLS=V7R3M0`

Targeting 7.3 seemed to compile fine for me.