### PR TITLE
Optimise toUpperCase implementation.

### DIFF
--- a/rpgle/REPL_VARS.RPGLEINC
+++ b/rpgle/REPL_VARS.RPGLEINC
@@ -180,6 +180,6 @@ dcl-pr markVariableAsUsed;
   variableId like(t_variable.id) const;
 end-pr;
 
-dcl-pr toUpperCase varchar(512);
+dcl-pr toUpperCase varchar(512) rtnparm;
   lowerString varchar(512) const;
 end-pr;

--- a/rpgle/REPL_VARS.SQLRPGLE
+++ b/rpgle/REPL_VARS.SQLRPGLE
@@ -1367,7 +1367,7 @@ end-proc;
 //-----------------------------------------------------------------------
 
 dcl-proc toUpperCase export;
-  dcl-pi *n varchar(512);
+  dcl-pi *n varchar(512) rtnparm;
     lowerString varchar(512) const;
   end-pi;
   dcl-s upperString varchar(512);


### PR DESCRIPTION
Thanks to Bob Cozzi for the suggestion.

Once the %upper BIF is a bit more established, we should look to replace
the usage of this custom procedure.