### PR TITLE
Build rule updates for Bob v2.3.3.

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -3,26 +3,21 @@ SUBDIRS = cmd db dsp rpgle bnd
 package:
 	$(call echo_cmd,"=== PACKAGE: Creating save file [$(OBJLIB)/RPGLEREPL]")
 	$(eval crtcmd := CRTSAVF FILE($(OBJLIB)/RPGLEREPL))
-	@$(PRESETUP);  \
-	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
-	$(POSTCLEANUP)
+	@$(PRESETUP) \
+	$(SCRIPTSPATH)/launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true
 	$(call echo_cmd,"=== PACKAGE: Granting public authority to library")
 	$(eval crtcmd := GRTOBJAUT OBJ($(OBJLIB)/*ALL) USER(*PUBLIC) OBJTYPE(*ALL) AUT(*ALL))
-	@$(PRESETUP);  \
-	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
-	$(POSTCLEANUP)
+	@$(PRESETUP) \
+	$(SCRIPTSPATH)/launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true
 	$(call echo_cmd,"=== PACKAGE: Granting public authority to objects")
 	$(eval crtcmd := GRTOBJAUT OBJ($(OBJLIB)/*ALL) USER(*PUBLIC) OBJTYPE(*ALL) AUT(*ALL))
-	@$(PRESETUP);  \
-	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
-	$(POSTCLEANUP)
+	@$(PRESETUP) \
+	$(SCRIPTSPATH)/launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true
 	$(call echo_cmd,"=== PACKAGE: Change ownership to QPGMR")
 	$(eval crtcmd := CHGOWN OBJ('/QSYS.LIB/$(OBJLIB).LIB') NEWOWN(QPGMR) SUBTREE(*ALL))
-	@$(PRESETUP);  \
-	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
-	$(POSTCLEANUP)
+	@$(PRESETUP) \
+	$(SCRIPTSPATH)/launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true
 	$(call echo_cmd,"=== PACKAGE: Saving objects to [$(OBJLIB)/RPGLEREPL]")
 	$(eval crtcmd := SAVOBJ OBJ(*ALL) LIB($(OBJLIB)) DEV(*SAVF) SAVF($(OBJLIB)/RPGLEREPL) CLEAR(*REPLACE) TGTRLS($(TGTRLS)) DTACPR(*YES) SELECT((*OMIT *ALL *FILE SAVF) (*OMIT *ALL *MODULE) (*OMIT EVFEVENT *FILE)))
-	@$(PRESETUP);  \
-	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
-	$(POSTCLEANUP)
+	@$(PRESETUP) \
+	$(SCRIPTSPATH)/launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true

--- a/rpgle/Rules.mk
+++ b/rpgle/Rules.mk
@@ -24,9 +24,8 @@ REPL_VARS.MODULE: $(d)/REPL_VARS.SQLRPGLE
 QRPGLEREF.FILE:
 	$(call echo_cmd,"=== Creating source PF [$(notdir $@)]")
 	$(eval crtcmd := CRTSRCPF FILE($(OBJLIB)/$(basename $(@F))) RCDLEN(112) CCSID(37) )
-	@$(PRESETUP);  \
-	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
-	$(POSTCLEANUP)
+	@$(PRESETUP) \
+	$(SCRIPTSPATH)/launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true
 
 # TODO: Generalise this into a generic recipe
 QRPGLEREF.FILE/REPL_HLPR.MBR: $(d)/REPL_HLPR.RPGLEINC | QRPGLEREF.FILE
@@ -34,18 +33,16 @@ QRPGLEREF.FILE/REPL_HLPR.MBR: $(d)/REPL_HLPR.RPGLEINC | QRPGLEREF.FILE
 	$(eval libpath = $(OBJPATH_$d))
 	$(call echo_cmd,"=== Creating ref member [$(notdir $@)]")
 	$(eval crtcmd := CPYFRMSTMF FROMSTMF('$<') TOMBR('$(libpath)/$@') MBROPT(*REPLACE) )
-	@$(PRESETUP);  \
-	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
-	$(POSTCLEANUP)
+	@$(PRESETUP) \
+	$(SCRIPTSPATH)/launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true
 
 QRPGLEREF.FILE/REPL_PSEUT.MBR: $(d)/REPL_PSEUT.RPGLEINC | QRPGLEREF.FILE
 	$(eval d = $($@_d))
 	$(eval libpath = $(OBJPATH_$d))
 	$(call echo_cmd,"=== Creating ref member [$(notdir $@)]")
 	$(eval crtcmd := CPYFRMSTMF FROMSTMF('$<') TOMBR('$(libpath)/$@') MBROPT(*REPLACE) )
-	@$(PRESETUP);  \
-	launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true; \
-	$(POSTCLEANUP)
+	@$(PRESETUP) \
+	$(SCRIPTSPATH)/launch "$(JOBLOGFILE)" "$(crtcmd)" >> $(LOGFILE) 2>&1 || true
 
 
 refs: $(REFs)


### PR DESCRIPTION
Bob has changed quite a bit since our previous version (v2.2.9). Instead of being a bunch of bash scripts, `makei` is now entirely written in Python.

We've taken advantage of some of the Bob-defined `make` functions in order to construct `QRPGLEREF` and do the packaging. Those functions have now changed, so I've updated the build rules as a result. I suspect we will have to do the same again in the near future - the HEAD of the Bob project shows that they're going to introduce feedback showing if a target built successfully, instead of plowing on regardless.

In terms of how we use `makei`, there are a couple of small interface changes. To build the project we now run:

`makei build` (`makei b` if you're impatient)

To run a particular build target, like for our `package` step, run:

`makei build -t package`