### PR TITLE
revert rtnparm change

### DIFF
--- a/rpgle/REPL_VARS.RPGLEINC
+++ b/rpgle/REPL_VARS.RPGLEINC
@@ -180,6 +180,6 @@ dcl-pr markVariableAsUsed;
   variableId like(t_variable.id) const;
 end-pr;
 
-dcl-pr toUpperCase varchar(512) rtnparm;
+dcl-pr toUpperCase varchar(512);
   lowerString varchar(512) const;
 end-pr;

--- a/rpgle/REPL_VARS.SQLRPGLE
+++ b/rpgle/REPL_VARS.SQLRPGLE
@@ -1367,11 +1367,11 @@ end-proc;
 //-----------------------------------------------------------------------
 
 dcl-proc toUpperCase export;
-  dcl-pi *n varchar(512) rtnparm;
+  dcl-pi *n varchar(512);
     lowerString varchar(512) const;
   end-pi;
   dcl-s upperString varchar(512);
-  exec sql SET :upperString = UPPER(:lowerString);
+  exec sql SET :upperString = UPPER(RTRIM(:lowerString));
   return upperString;
 end-proc;
 


### PR DESCRIPTION
I'm getting constant crashes with this change in of pointer not set - I wonder if it's because we're accepting (and returning) a varchar(512), but calling it with a char(71).

I don't know if you'd had any more luck in seeing it working? Otherwise, I'm just going to back it out for now and have a play with it later.