### PR TITLE
Support comma decimal separators

### DIFF
--- a/rpgle/REPL_EVAL.RPGLE
+++ b/rpgle/REPL_EVAL.RPGLE
@@ -350,9 +350,9 @@ dcl-proc replResult_evaluate_fld_single export;
   insertSingleLineOfGeneratedCode
     ('      (SELECT :repl_line,');
   insertSingleLineOfGeneratedCode
-    ('              COALESCE(MAX(result_number),0)+1,');
+    ('              COALESCE(MAX(result_number), 0)+1,');
   insertSingleLineOfGeneratedCode
-    ('              TRIM(:repl_name) || '' = '' ||');
+    ('              TRIM(:repl_name) CONCAT '' = '' CONCAT');
 
   if variable.type = 'indicator' or variable.type = '*indicator';
     insertSingleLineOfGeneratedCode
@@ -367,8 +367,7 @@ dcl-proc replResult_evaluate_fld_single export;
   else;
     insertSingleLineOfGeneratedCode
       ('              '''''''''
-        + '|| TRIM(CAST(:repl_i AS CHAR(1000))) '
-        + '|| ''''''''');
+        + 'CONCAT TRIM(CAST(:repl_i AS CHAR(1000))) ' + 'CONCAT ''''''''');
   endif;
 
   insertSingleLineOfGeneratedCode

--- a/rpgle/REPL_HLPR.SQLRPGLE
+++ b/rpgle/REPL_HLPR.SQLRPGLE
@@ -27,7 +27,7 @@ dcl-proc replHlpr_recordSqlResult export;
   exec sql
     INSERT INTO replrslt
       (line_number, result_number, result_description)
-      (SELECT :line, COALESCE(MAX(result_number),0)+1,
+      (SELECT :line, COALESCE(MAX(result_number), 0)+1,
               :resultDescription
          FROM replrslt
         WHERE session_id = QSYS2.JOB_NAME
@@ -113,8 +113,8 @@ dcl-proc replResult_rpgIndicator export;
     INSERT INTO replrslt
       (line_number, result_number, result_description)
       (SELECT :repl_line,
-              COALESCE(MAX(result_number),0)+1,
-              TRIM(:repl_name) || ' = ' ||
+              COALESCE(MAX(result_number), 0)+1,
+              TRIM(:repl_name) CONCAT ' = ' CONCAT
               CASE WHEN :repl_i = 1
                 THEN 'true'
                 ELSE 'false' END

--- a/rpgle/REPL_INS.SQLRPGLE
+++ b/rpgle/REPL_INS.SQLRPGLE
@@ -24,7 +24,7 @@ dcl-proc insertSingleLineOfGeneratedCode export;
       INSERT INTO qtemp/repl_alias
         (srcdta)
       VALUES
-        ('     ' || :code);
+        ('     ' CONCAT :code);
 
   else;
 
@@ -32,7 +32,7 @@ dcl-proc insertSingleLineOfGeneratedCode export;
       INSERT INTO qtemp/repl_alias
         (srcdta)
       VALUES
-        ('       ' || :code);
+        ('       ' CONCAT :code);
 
   endif;
 

--- a/rpgle/REPL_VARS.SQLRPGLE
+++ b/rpgle/REPL_VARS.SQLRPGLE
@@ -1022,7 +1022,7 @@ dcl-proc fetchStoredVariable export;
 
     SELECT CAST(CASE WHEN parentQualified = 'Y'
                         THEN TRIM(parent_data_structure)
-                             || '.' || variable_name
+                             CONCAT '.' CONCAT variable_name
                       ELSE variable_name END AS CHAR(70)),
             CAST(variable_type AS CHAR(10)),
             COALESCE(array_size, 0),
@@ -1041,8 +1041,8 @@ dcl-proc fetchStoredVariable export;
       WHERE session_id = (QSYS2.JOB_NAME)
            AND (UPPER(variable_name) = UPPER(:variableName)
                 OR UPPER(TRIM(parent_data_structure)
-                         || '.'
-                         || TRIM(variable_name))
+                         CONCAT '.'
+                         CONCAT TRIM(variable_name))
                    = UPPER(:variableName))
            AND variable_scope = :scope;
 
@@ -1149,7 +1149,7 @@ dcl-proc prepareListOfDataStructureFields export;
      SELECT DISTINCT
             CAST(CASE WHEN parentQualified = 'Y'
                         THEN TRIM(parent_data_structure)
-                             || '.' || variable_name
+                             CONCAT '.' CONCAT variable_name
                       ELSE variable_name END AS CHAR(70)),
             CAST(variable_type AS CHAR(10)),
             COALESCE(array_size, 0),
@@ -1260,7 +1260,7 @@ dcl-proc prepareListOfVariables export;
      SELECT DISTINCT
             CAST(CASE WHEN COALESCE(parentQualified, 'N') = 'Y'
                         THEN TRIM(parent_data_structure)
-                             || '.' || variable_name
+                             CONCAT '.' CONCAT variable_name
                       ELSE variable_name END AS CHAR(70)),
             CAST(variable_type AS CHAR(10)),
             COALESCE(array_size, 0),


### PR DESCRIPTION
Resolve an issue found whereby a French-language i was unable to compile - at least partly because ",0" means something else in that language setting. A similar problem seemed to occur with vertical pipes but not explicitly declaring CONCAT.